### PR TITLE
fix: ignore modem settings, http 4xx

### DIFF
--- a/aiomobilevikings/client.py
+++ b/aiomobilevikings/client.py
@@ -171,7 +171,8 @@ class MobileVikingsClient:
             _LOGGER.debug(f"404 Error: {error_data}")
             return error_data
         elif str(response.status_code).startswith("4"):
-            _LOGGER.debug(f"{response.status_code} Error: {response.json()}")
+            error_data = response.json()
+            _LOGGER.debug(f"{response.status_code} Error: {error_data}")
             return False
         else:
             error_message = f"Request failed. Status code: {response.status_code}"

--- a/aiomobilevikings/client.py
+++ b/aiomobilevikings/client.py
@@ -170,6 +170,9 @@ class MobileVikingsClient:
             error_data = response.json()
             _LOGGER.debug(f"404 Error: {error_data}")
             return error_data
+        elif str(response.status_code).startswith("4"):
+            _LOGGER.debug(f"{response.status_code} Error: {response.json()}")
+            return False
         else:
             error_message = f"Request failed. Status code: {response.status_code}"
             try:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for client requests, specifically for HTTP status codes in the 400 range (excluding 404).
  
- **Documentation**
	- Clarified documentation for the `get_data` method regarding error reporting in API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->